### PR TITLE
fix(agni): correct radians-to-degrees conversion for zenith angle

### DIFF
--- a/agni.py
+++ b/agni.py
@@ -95,7 +95,7 @@ def init_agni_atmos(vulcan_cfg:Config, atm:AtmData, var:Variables):
                         sflux_integ,
                         vulcan_cfg.f_diurnal,
                         0.0,
-                        vulcan_cfg.sl_angle*np.pi/180.0, # convert to degrees
+                        vulcan_cfg.sl_angle*180.0/np.pi, # convert to degrees
 
                         vulcan_cfg.Tsurf_guess,
                         vulcan_cfg.gs*0.01, # convert to SI, m/s^2


### PR DESCRIPTION
The zenith angle (`sl_angle`) is stored in radians internally (per VULCAN convention), but AGNI expects degrees. The conversion was inverted — `np.pi/180` converts *from* degrees to radians, when we need the opposite.

Swapped to `180.0/np.pi` so the value passed to `AGNI.atmosphere.setup_b()` is actually in degrees as expected.